### PR TITLE
Add LiveCollect streamer tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,10 @@ If you dont have Designs for *"Will be back soon"* kind of screens, just leaving
 [Jamendo](http://jamendo.com) is a web service where you can find free music without copyright nor royalty costs,
 you can download full quality music for free to use on your streams and dont get muted, etc.
 
+## LiveCollect
+
+[LiveCollect](https://livecollect.tv) is a web-based Twitch tool that turns subscriptions into collectible on-stream pack openings through an OBS browser source. Viewers can collect cards, track rarities, and build their collection over time.
+
 
 ## PeerFast
 


### PR DESCRIPTION
Added a new section for LiveCollect, a web-based Twitch tool that turns subscriptions into collectible on-stream pack openings through an OBS browser source.

## What kind of change does this PR introduce?

Adds a new web-based streaming tool/resource to the list :)


## What is the current behavior?

LiveCollect is not currently included in the Awesome Streaming Tools list.


## What is the new behavior?

Adds LiveCollect under the Web Based Tools section.  
It is a web-based Twitch tool that uses an OBS browser source to turn subscriptions into collectible live pack openings


## Additional context

I believe LiveCollect fits the repository because it is a streamer tool designed for more viewer-interaction and an extra reason for people to subscribe. 
