### PR TITLE
Add NoSub

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,12 @@ The service is NOT Free, you must pay, prices may vary.
 [StreamTranslate](https://streamtranslate.live) -
 Real-time translated subtitles for Twitch, YouTube, Kick, and TikTok streams in 49 languages through an OBS browser source.
 
+## NoSub
+
+[NoSub](https://nosubapp.com) is a free web player for Twitch and Kick VODs, including sub-only replays the platforms still serve, with the original chat replayed in sync and searchable.
+
+It marks the passages Twitch muted for copyright on the seek bar so you can skip them, shows chapters to jump between games, and cuts shareable clips. No account, nothing to install, available in English, French, Spanish and Portuguese.
+
 # Twitch Extensions
 
 Few Twitch extensions for tech streams, random order, as example, theres always more on the Twitch catalog.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update — adds one entry to the "Web Based Tools" section.

## What is the current behavior?

The list has no entry for watching Twitch or Kick VODs. The closest tools cover
clipping (ClipMe, ClipSpeedAI) or subtitles (StreamTranslate), but nothing for
replaying a past broadcast with its chat. No linked issue.

## What is the new behavior?

Adds NoSub at the end of "Web Based Tools", following the section's format:
a `##` heading, the link opening the sentence, and two short paragraphs.

NoSub is a free web player for Twitch and Kick VODs, including sub-only replays
the platforms still serve, with the original chat replayed in sync and
searchable. It marks the passages Twitch muted for copyright on the seek bar so
they can be skipped, shows chapters to jump between games, and cuts shareable
clips. No account, nothing to install, available in English, French, Spanish
and Portuguese.

No screenshots — text-only change, one entry, nothing else touched.

## Additional context

Disclosure: I'm the developer of NoSub, so please treat this as a submission
rather than an independent recommendation.

Free and ad-supported, no paid tier and no trial. It hosts nothing and stores
no copy of any video — it reads the public sources the platforms already serve,
so it can't recover deleted, private or expired VODs.

Happy to reword or move the entry if you'd prefer it elsewhere.
