### PR TITLE
Add Emote Resizer — free client-side emote/badge/sticker resizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,11 @@ is a lot more lightweigth than the official app and the features are almost the 
 
 # Web Based Tools
 
+## Emote Resizer
+
+[Emote Resizer](https://emoteresize.com) is a free, fully client-side tool that resizes one image into every Twitch, Discord, 7TV/BTTV/FFZ, and Slack emote/badge/sticker size.
+Handles PNG and animated GIF, batch processing, and automatic compression. Nothing is uploaded — everything runs in your browser.
+
 ## RunCue
 
 [RunCue](https://runcue.fly.dev/launch?utm_source=awesome_streaming_tools&utm_medium=resource_list&utm_campaign=runcue_launch) is a browser timer and cue board for webinars and remote productions.


### PR DESCRIPTION
## What
Adds **Emote Resizer** (https://emoteresize.com) to the _Web Based Tools_ section.

## Why it fits
Emote Resizer is a free, fully client-side tool that exports one image into every size Twitch, Discord, 7TV/BTTV/FFZ, and Slack need for emotes, badges, and stickers (PNG & animated GIF, batch, auto-compressed, nothing uploaded). It's directly relevant to streamers and Discord community managers — the exact audience this list serves, and a natural companion to the existing BetterTTV / 7TV / FFZ emote entries.

## Notes
- Free, no account, no upload (privacy-friendly).
- Inserted as a new `## Emote Resizer` subsection following the existing entry style.
- Happy to adjust placement, wording, or move it under a different section if you prefer.