### PR TITLE
Add NeonStreamLab free overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Overlays has an online web visual editor with a lot of free themes to use and re
 Overlays and Alerts are important because is the only *visual* way to know when someone is giving you money,
 like Donations, Bits, Cheers, etc and also important events like Raids with lots of new viewers.
 
+## NeonStreamLab
+
+[NeonStreamLab](https://neonstreamlab.com/free) offers free themed stream overlay packs for OBS Studio, Streamlabs and StreamElements. Packs include animated starting, BRB and ending screens, webcam frames, chat overlays, alerts and matching panels for Twitch, YouTube, Kick and VTubers.
+
 ## Fikir Overlay
 
 [Fikir Overlay](https://github.com/EEspinoso/fikir-overlay) is a free open source Node.js overlay that lets viewers submit ideas via chat commands (`/idea`, `/fikir`, and 30+ language triggers) on YouTube, Twitch and Kick. Accepted ideas appear as draggable post-it notes on the OBS overlay. Includes a streamer control panel, stats dashboard, multi-language UI (10 languages), rate limiting, profanity filter, and SQLite storage.


### PR DESCRIPTION
Adds NeonStreamLab to the Overlays section with a direct link to its free themed stream overlay packs.

## What kind of change does this PR introduce?

Documentation update / new streaming resource.

## What is the current behavior?

The list does not currently include NeonStreamLab.

## What is the new behavior?

Adds a concise entry for free overlay packs compatible with OBS Studio, Streamlabs and StreamElements, covering Twitch, YouTube, Kick and VTubers.

## Additional context

Only README.md is changed: 4 additions, 0 deletions.