### PR TITLE
Added Boltis to Desktop Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ if you dont understand why a lot of people on your chat types `monkaS` is probab
 you can also add you own customized animated emotes for your chat, also supports not-animated emotes, its free $0 cost.
 
 
+## Boltis
+
+[Boltis](https://boltis.app) is a free Windows app that clips your Twitch stream with one hotkey, saving the last 60 seconds via Twitch's official clip API with no FPS impact. It has a built-in editor to crop clips to vertical, add captions, cuts and GIF/text/image overlays, and export for TikTok and Shorts. You pick the moment live rather than letting AI guess it. Exported clips have no watermark.
+
+[![](https://boltis.app/images/edit-and-export.png)](https://boltis.app)
+
+
 ## Orion
 
 [Orion](https://alamminsalo.github.io/orion) is an open source crossplatform Qt5/QML Twitch Desktop Client app, with all basic features working,


### PR DESCRIPTION
Added information about the Boltis app for clipping Twitch streams.

## What kind of change does this PR introduce?
Docs update.

## What is the current behavior?
Boltis is not listed.

## What is the new behavior?
Adds Boltis to Desktop Apps: a free Windows Twitch clip tool I built. One hotkey saves the last 60 seconds via Twitch's official clip API, with a built-in vertical editor for TikTok and Shorts. Placed alphabetically after BetterTTV.

## Additional context
Per the contributing rules: exported clips have no watermark, and the core is free and clean.
